### PR TITLE
MD5: Fix quaternion conversions

### DIFF
--- a/code/MD5Loader.cpp
+++ b/code/MD5Loader.cpp
@@ -285,9 +285,6 @@ void MD5Importer::AttachChilds_Mesh(int iParentID,aiNode* piParent, BoneList& bo
                 aiQuaternion quat;
                 MD5::ConvertQuaternion ( bones[i].mRotationQuat, quat );
 
-                // FIX to get to Assimp's quaternion conventions
-                quat.w *= -1.f;
-
                 bones[i].mTransform = aiMatrix4x4 ( quat.GetMatrix());
                 bones[i].mTransform.a4 = bones[i].mPositionXYZ.x;
                 bones[i].mTransform.b4 = bones[i].mPositionXYZ.y;
@@ -656,9 +653,6 @@ void MD5Importer::LoadMD5AnimFile ()
 
                     MD5::ConvertQuaternion(vTemp, qKey->mValue);
                     qKey->mTime = vKey->mTime = dTime;
-
-                    // we need this to get to Assimp quaternion conventions
-                    qKey->mValue.w *= -1.f;
                 }
             }
 

--- a/code/MD5Parser.h
+++ b/code/MD5Parser.h
@@ -262,6 +262,9 @@ inline void ConvertQuaternion (const aiVector3D& in, aiQuaternion& out) {
     if (t < 0.0f)
         out.w = 0.0f;
     else out.w = std::sqrt (t);
+
+    // Assimp convention.
+    out.w *= -1.f;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Some of the quaternions loaded from MD5 files were not converted to follow Assimp conventions.

https://github.com/assimp/assimp/issues/495